### PR TITLE
Add FastAPI backend and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # ai-wordcloud
+
+This project provides a simple FastAPI backend for generating word cloud images
+using text from OpenAI completions.
+
+## Running the API locally
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Export your OpenAI API key so the backend can authenticate with the
+   OpenAI service:
+
+```bash
+export OPENAI_API_KEY=YOUR_KEY
+```
+
+3. Start the application with Uvicorn:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+The API will be available at `http://127.0.0.1:8000`. You can send a POST request
+to `/generate` with a JSON body containing a `prompt` field to receive a
+base64-encoded PNG image of the generated word cloud.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import openai
+from wordcloud import WordCloud
+import imageio.v2 as imageio
+from io import BytesIO
+import base64
+
+app = FastAPI()
+
+class Prompt(BaseModel):
+    prompt: str
+
+@app.post("/generate")
+async def generate(prompt: Prompt):
+    """Generate a word cloud image from an OpenAI completion."""
+    # Call OpenAI API to expand the prompt
+    completion = openai.Completion.create(
+        engine="text-davinci-003",
+        prompt=prompt.prompt,
+        max_tokens=100,
+    )
+    text = completion.choices[0].text
+
+    # Build the word cloud from the generated text
+    wc = WordCloud(width=800, height=400).generate(text)
+    img_array = wc.to_array()
+
+    # Encode image to base64 PNG
+    buf = BytesIO()
+    imageio.imwrite(buf, img_array, format="png")
+    encoded = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return {"image": encoded}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+openai
+wordcloud
+imageio


### PR DESCRIPTION
## Summary
- create `backend` with a small FastAPI app exposing `/generate`
- list required packages in `requirements.txt`
- document how to run the service locally

## Testing
- `python3 -m pip install -r requirements.txt`
- `uvicorn --help | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_687fba69fb20832d93dd9f258e02c613